### PR TITLE
Feed TdsOperationStatus through in SqlDataReader

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDataReader.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDataReader.cs
@@ -3533,7 +3533,7 @@ namespace Microsoft.Data.SqlClient
                             if (result != TdsOperationStatus.Done)
                             {
                                 more = false;
-                                return TdsOperationStatus.Done;
+                                return result;
                             }
 
                             // In the case of not closing the reader, null out the metadata AFTER


### PR DESCRIPTION
Spot fix - this differs between netcore and netfx, and might cause issues when calling `SqlDataReader.NextResult`.

Edit: closing, it's been rolled up into the codebase outside this PR.